### PR TITLE
For Ubuntu >= 13.04 install lib32stdc++6 package

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -32,20 +32,21 @@ android_bin      = File.join(android_home, 'tools', 'android')
 #
 # Install required libraries
 #
-if (node['platform'] == 'ubuntu')
+if node['platform'] == 'ubuntu'
   package 'libgl1-mesa-dev'
-end
 
-#
-# Install required 32-bit libraries on 64-bit platforms
-#
-if (node['os'] == 'linux' && node['kernel']['machine'] != 'i686')
-  if (node['platform'] == 'ubuntu')
-    #TODO should check it is an ubuntu 11.10+
-    package 'libstdc++6:i386'
+  #
+  # Install required 32-bit libraries on 64-bit platforms
+  #
+  if node['kernel']['machine'] != 'i686'
+    # http://askubuntu.com/questions/147400/problems-with-eclipse-and-android-sdk
+    if Chef::VersionConstraint.new(">= 13.04").include?(node['platform_version'])
+      package 'lib32stdc++6'
+    elsif Chef::VersionConstraint.new(">= 11.10").include?(node['platform_version'])
+      package 'libstdc++6:i386'
+    end
+
     package 'lib32z1'
-  else
-    Chef::Application.fatal!("This 'Android SDK' cookbook currently only supports ubuntu 64-bit and other linux 32-bit platforms, but this node is a #{node['platform']}/#{node['kernel']['machine']} box.")
   end
 end
 


### PR DESCRIPTION
Ubuntu >= 13.04 does not have libstdc++6:i386 packages in default repositories.

Also, I don't think if we should throw an error for all i686 architectures.
