### PR TITLE
only install the sdk if the target directory doesn't already exist

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -119,4 +119,5 @@ script 'Install Android SDK platforms and tools' do
       eof
     }
   EOF
+  not_if { File.exist?("#{setup_root}/#{node['android-sdk']['name']}-#{node['android-sdk']['version']}") }
 end


### PR DESCRIPTION
At present the script block in default.rb will re-install the sdk on every run. Adding a not_if block will prevent this if the target directory already exists.
