### PR TITLE
Loop over node components to generate project string for maven-android-sdk-deployer

### DIFF
--- a/recipes/maven-rescue.rb
+++ b/recipes/maven-rescue.rb
@@ -36,17 +36,14 @@ node['android-sdk']['components'].each do |sdk_component|
   if sdk_component =~ /android-[0-9]+/
     components << sdk_component.sub("android", "platforms/android")
   # android and GDK addon APIs
-  else if sdk_component =~ /addon-google_(apis|gdk)-google-[0-9]+/
-      components << sdk_component.sub("addon-google_", "add-ons/google-").sub("-google","")
-    # m2 repositories
-    else if sdk_component =~ /extra-(google|android)-m2repository/
-        components << sdk_component.sub("extra-", "repositories/")
-      # extras
-      else if sdk_component =~ /extra-google-+/
-          components << sdk_component.sub("extra-google-", "extras/").gsub("_","-")
-        end
-      end
-    end
+  elsif sdk_component =~ /addon-google_(apis|gdk)-google-[0-9]+/
+    components << sdk_component.sub("addon-google_", "add-ons/google-").sub("-google","")
+  # m2 repositories
+  elsif sdk_component =~ /extra-(google|android)-m2repository/
+    components << sdk_component.sub("extra-", "repositories/")
+  # extras
+  elsif sdk_component =~ /extra-google-+/
+    components << sdk_component.sub("extra-google-", "extras/").gsub("_","-")
   end
 end
 


### PR DESCRIPTION
It checks for package prefixes and converts to folders : 
- platforms
- add-ons
- repositories
- extras

A few packages in extra's have name that differs from the targets in maven-android-sdk-deployer, these are not yet covered by this script : 
- admob
- google-play-services-for-froyo
- ...

Possible solutions : 
- convert the name in the script to match the targets in maven-android-sdk-deployer
- rename these targets in maven-android-sdk-deployer : Update :  I created a pull request renaming  the targets : https://github.com/mosabua/maven-android-sdk-deployer/pull/225 (@mosabua), which was merged.
