### PR TITLE
Allow ignoring installing expect

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -57,4 +57,6 @@ default['android-sdk']['scripts']['group']          = node['android-sdk']['group
 
 default['android-sdk']['java_from_system']          = false
 
+default['android-sdk']['expect_from_system']        = false
+
 default['android-sdk']['maven-rescue']              = false

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -99,7 +99,7 @@ template "/etc/profile.d/#{node['android-sdk']['name']}.sh" do
   only_if { node['android-sdk']['set_environment_variables'] }
 end
 
-package 'expect'
+package 'expect' unless node['android-sdk']['expect_from_system']
 
 #
 # Install, Update (a.k.a. re-install) Android components


### PR DESCRIPTION
Similar to `java_from_system` attribute, allow for ignoring `expect`