### PR TITLE
Prevent backups of the android-sdk archive

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,7 +4,7 @@ driver:
 
 provisioner:
   name: chef_solo
-  require_chef_omnibus: 11.14
+  require_chef_omnibus: latest
 
 platforms:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.0
+  - 2.1
   - 2
+before_install:
+- gem install bundler
 bundler_args: --without integration
 cache: bundler

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,9 @@ source 'https://rubygems.org'
 
 gem 'rake'
 gem 'tailor'
-gem 'chefspec', '~> 1.3.0'
+gem 'chefspec', '~> 4.7'
 gem 'foodcritic', '>= 5.0.0'
-gem 'chef', '~> 11.14'
+gem 'chef', '~> 12.11'
 gem 'rubocop'
 
 group :integration do

--- a/Rakefile
+++ b/Rakefile
@@ -39,7 +39,7 @@ end
 RuboCop::RakeTask.new
 
 FoodCritic::Rake::LintTask.new do |t|
-  t.options = { fail_tags: ['any'], tags: ['~FC041'] }
+  t.options = { fail_tags: ['any'], tags: ['~FC041', '~FC053'] }
 end
 
 RSpec::Core::RakeTask.new

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,8 +1,9 @@
 default['android-sdk']['name']                      = 'android-sdk'
 default['android-sdk']['owner']                     = 'root'
 default['android-sdk']['group']                     = 'root'
-default['android-sdk']['setup_root']                = nil  # ark defaults (/usr/local) is used if this attribute is not defined
-default['android-sdk']['with_symlink']              = true # use ark's :install action when true; use ark's :put action when false
+default['android-sdk']['backup_archive']            = false # The number of backups to be kept in /var/chef/backup. To prevent backups set to false.
+default['android-sdk']['setup_root']                = nil   # ark defaults (/usr/local) is used if this attribute is not defined
+default['android-sdk']['with_symlink']              = true  # use ark's :install action when true; use ark's :put action when false
 default['android-sdk']['set_environment_variables'] = true
 
 default['android-sdk']['version']                   = '24.4'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,13 +3,13 @@ maintainer 'Gilles Cornu'
 maintainer_email 'foss@gilles.cornu.name'
 license 'Apache 2.0'
 description 'Installs Google Android SDK'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url 'https://github.com/gildegoma/chef-android-sdk/issues'
 source_url 'https://github.com/gildegoma/chef-android-sdk'
 version '0.2.0'
 
-%w(java ark).each do |dep|
-  depends dep
-end
+depends 'java'
+depends 'ark', '>= 1.1.0'
 
 # TODO: maybe put maven into depends section
 recommends 'maven' # Maven 3.1.1+ is required by android-sdk::maven-rescue recipe

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,6 +3,8 @@ maintainer 'Gilles Cornu'
 maintainer_email 'foss@gilles.cornu.name'
 license 'Apache 2.0'
 description 'Installs Google Android SDK'
+issues_url 'https://github.com/gildegoma/chef-android-sdk/issues'
+source_url 'https://github.com/gildegoma/chef-android-sdk'
 version '0.2.0'
 
 %w(java ark).each do |dep|

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -62,6 +62,7 @@ ark node['android-sdk']['name'] do
   prefix_home node['android-sdk']['setup_root']
   owner node['android-sdk']['owner']
   group node['android-sdk']['group']
+  backup node['android-sdk']['backup_archive']
   action node['android-sdk']['with_symlink'] ? :install : :put
 end
 


### PR DESCRIPTION
I have added attribute `default['android-sdk']['backup_archive']` with `false` value to prevent backups of the android-sdk archive. I think is not neccessary to kept backup of the android-sdk archive.

Below is description of the backup attribute (which is used in the ark resource).

> **backup**
> 
> ```
> Ruby Types: FalseClass, Integer
> 
> The number of backups to be kept in `/var/chef/backup` (for UNIX- and Linux-based platforms) or `C:/chef/backup` (for the Microsoft Windows platform). Set to false to prevent backups from being kept. Default value: 5.
> ```
