### PR TITLE
Remove use of Chef::Resource::Script#path

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -117,7 +117,6 @@ unless File.exist?("#{setup_root}/#{node['android-sdk']['name']}/temp")
     script "Install Android SDK component #{sdk_component}" do
       interpreter 'expect'
       environment 'ANDROID_HOME' => android_home
-      path [File.join(android_home, 'tools')]
       user node['android-sdk']['owner']
       group node['android-sdk']['group']
       # TODO: use --force or not?


### PR DESCRIPTION
because it does not exist in Chef 13.x and is not necessary given the use of the full `android_bin` path.